### PR TITLE
Support mapping of Australian Timezones

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in time_range_extractor.gemspec
+gem 'activesupport', '~> 5'
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,18 @@
 PATH
   remote: .
   specs:
-    time_range_extractor (0.2.3)
+    time_range_extractor (0.3.5)
       activesupport (> 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
+    activesupport (6.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -22,7 +23,7 @@ GEM
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     equalizer (0.0.11)
@@ -47,7 +48,7 @@ GEM
     guard-rubocop (1.3.0)
       guard (~> 2.0)
       rubocop (~> 0.20)
-    i18n (1.6.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     jaro_winkler (1.5.3)
@@ -93,7 +94,7 @@ GEM
     shellany (0.0.1)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
     virtus (1.0.5)
@@ -101,6 +102,7 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,12 +7,11 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -23,7 +22,7 @@ GEM
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.5)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     equalizer (0.0.11)
@@ -48,7 +47,7 @@ GEM
     guard-rubocop (1.3.0)
       guard (~> 2.0)
       rubocop (~> 0.20)
-    i18n (1.8.2)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     jaro_winkler (1.5.3)
@@ -94,7 +93,7 @@ GEM
     shellany (0.0.1)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tzinfo (1.2.7)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
     virtus (1.0.5)
@@ -102,12 +101,12 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 5)
   bundler (~> 2.0)
   guard (>= 2)
   guard-minitest (>= 2.4)

--- a/lib/time_range_extractor.rb
+++ b/lib/time_range_extractor.rb
@@ -5,6 +5,7 @@ require 'date'
 require 'active_support/time'
 
 require 'time_range_extractor/match_result'
+require 'time_range_extractor/time_zone_adjusted_match_result'
 require 'time_range_extractor/parser'
 require 'time_range_extractor/version'
 

--- a/lib/time_range_extractor/parser.rb
+++ b/lib/time_range_extractor/parser.rb
@@ -29,7 +29,7 @@ module TimeRangeExtractor
 
     def call
       match = PATTERN.match(@text)
-      result = MatchResult.new(match)
+      result = TimeZoneAdjustedMatchResult.new(match)
       return nil unless result.valid?
 
       time_range_from(result)

--- a/lib/time_range_extractor/parser.rb
+++ b/lib/time_range_extractor/parser.rb
@@ -56,7 +56,7 @@ module TimeRangeExtractor
 
     # :reek:UtilityFunction so that we can optionally include ActiveSupport
     def time_parser
-      ::Time.zone || ::Time
+      ::Time.zone || ::DateTime
     end
   end
 end

--- a/lib/time_range_extractor/time_zone_adjusted_match_result.rb
+++ b/lib/time_range_extractor/time_zone_adjusted_match_result.rb
@@ -2,18 +2,21 @@
 
 module TimeRangeExtractor
   class TimeZoneAdjustedMatchResult < MatchResult
+    # This works around Ruby's lack of support for the following timezones.
+    # It has been fixed in Ruby 2.7.x versions.  Until we are able to upgrade
+    # this mapping will help but it's not a complete fix as
+    # Central Australian times aren't handled.
+    #
+    # More details:
+    #  * https://github.com/ruby/date/pull/16
+    #  * https://github.com/rails/rails/issues/36972#issuecomment-526260754
     def time_zone
       case match_data[:time_zone]
-      when "AEST"
-        "EAST"
-      when "AWST"
-        "WAST"
-      when "AEDT"
-        "EADT"
-      when "AWDT"
-        "WADT"
-      else
-        match_data[:time_zone]
+      when 'AEST' then 'EAST'
+      when 'AWST' then 'WAST'
+      when 'AEDT' then 'EADT'
+      when 'AWDT' then 'WADT'
+      else super
       end
     end
   end

--- a/lib/time_range_extractor/time_zone_adjusted_match_result.rb
+++ b/lib/time_range_extractor/time_zone_adjusted_match_result.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module TimeRangeExtractor
+  class TimeZoneAdjustedMatchResult < MatchResult
+    def time_zone
+      case match_data[:time_zone]
+      when "AEST"
+        "EAST"
+      when "AWST"
+        "WAST"
+      when "AEDT"
+        "EADT"
+      when "AWDT"
+        "WADT"
+      else
+        match_data[:time_zone]
+      end
+    end
+  end
+end

--- a/lib/time_range_extractor/version.rb
+++ b/lib/time_range_extractor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TimeRangeExtractor
-  VERSION = '0.3.0'
+  VERSION = '0.3.5'
 end

--- a/test/time_range_extractor_test.rb
+++ b/test/time_range_extractor_test.rb
@@ -35,9 +35,21 @@ class TimeRangeExtractorTest < Minitest::Test
   ].each do |time_string, range|
     define_method "test_should_handle_#{time_string.gsub(' ', '_')}" do
       result = TimeRangeExtractor.call("Call at #{time_string} please")
-
-      assert_equal Time.parse(range[0]), result.begin
       assert_equal Time.parse(range[1]), result.end
+      assert_equal Time.parse(range[0]), result.begin
+    end
+  end
+
+  # Australian Time Zone mapping to work around ruby bug
+
+  [
+    ['4 pm - 5 pm AEST', ['16:00:00 +1000', '17:00:00 +1000']]
+  ].each do |time_string, range|
+    define_method "test_should_map_australian_zones_for_#{time_string.gsub(' ', '_')}" do
+      result = TimeRangeExtractor.call("Call at #{time_string} please")
+      puts Time.parse(range[1])
+      assert_equal Time.parse(range[1]), result.end
+      assert_equal Time.parse(range[0]), result.begin
     end
   end
 

--- a/test/time_range_extractor_test.rb
+++ b/test/time_range_extractor_test.rb
@@ -35,21 +35,23 @@ class TimeRangeExtractorTest < Minitest::Test
   ].each do |time_string, range|
     define_method "test_should_handle_#{time_string.gsub(' ', '_')}" do
       result = TimeRangeExtractor.call("Call at #{time_string} please")
-      assert_equal Time.parse(range[1]), result.end
-      assert_equal Time.parse(range[0]), result.begin
+      assert_equal time_parser.parse(range[1]), result.end
+      assert_equal time_parser.parse(range[0]), result.begin
     end
   end
 
   # Australian Time Zone mapping to work around ruby bug
-
   [
-    ['4 pm - 5 pm AEST', ['16:00:00 +1000', '17:00:00 +1000']]
+    ['4 pm - 5 pm AEST', ['16:00:00 EAST', '17:00:00 EAST']],
+    ['4 pm - 5 pm AEDT', ['16:00:00 EADT', '17:00:00 EADT']],
+    ['4 pm - 5 pm AWST', ['16:00:00 WAST', '17:00:00 WAST']],
+    ['4 pm - 5 pm AWDT', ['16:00:00 WADT', '17:00:00 WADT']]
   ].each do |time_string, range|
-    define_method "test_should_map_australian_zones_for_#{time_string.gsub(' ', '_')}" do
+    define_method "test_should_map_zones_for_#{time_string.gsub(' ', '_')}" do
       result = TimeRangeExtractor.call("Call at #{time_string} please")
-      puts Time.parse(range[1])
-      assert_equal Time.parse(range[1]), result.end
-      assert_equal Time.parse(range[0]), result.begin
+
+      assert_equal time_parser.parse(range[1]), result.end
+      assert_equal time_parser.parse(range[0]), result.begin
     end
   end
 
@@ -61,8 +63,8 @@ class TimeRangeExtractorTest < Minitest::Test
     define_method "test_should_handle_#{time_string.gsub(' ', '_')}" do
       result = TimeRangeExtractor.call("Call at #{time_string} please")
 
-      assert_equal Time.parse(range[0]), result.begin
-      assert_equal Time.parse(range[1]), result.end
+      assert_equal time_parser.parse(range[0]), result.begin
+      assert_equal time_parser.parse(range[1]), result.end
     end
   end
 
@@ -88,8 +90,8 @@ class TimeRangeExtractorTest < Minitest::Test
   def test_should_span_days_if_necessary
     result = TimeRangeExtractor.call('Random text 11pm - 1am for context')
 
-    assert_equal Time.parse('11pm'), result.begin
-    assert_equal Time.parse('1am') + 1.day, result.end
+    assert_equal time_parser.parse('11pm'), result.begin
+    assert_equal time_parser.parse('1am') + 1.day, result.end
   end
 
   def test_should_return_nil_if_no_times_found
@@ -103,8 +105,8 @@ class TimeRangeExtractorTest < Minitest::Test
       'The meeting is from 4-5pm but we will follow up from 6-7pm'
     )
 
-    assert_equal Time.parse('4pm'), result.begin
-    assert_equal Time.parse('5pm'), result.end
+    assert_equal time_parser.parse('4pm'), result.begin
+    assert_equal time_parser.parse('5pm'), result.end
   end
 
   def test_should_handle_line_breaks
@@ -114,15 +116,15 @@ class TimeRangeExtractorTest < Minitest::Test
       Can you call me from 4-5pm
     TEXT
 
-    assert_equal Time.parse('4pm'), result.begin
-    assert_equal Time.parse('5pm'), result.end
+    assert_equal time_parser.parse('4pm'), result.begin
+    assert_equal time_parser.parse('5pm'), result.end
   end
 
   def test_should_handle_times_at_the_start_of_the_string
     result = TimeRangeExtractor.call('8-8:30am')
 
-    assert_equal Time.parse('8am'), result.begin
-    assert_equal Time.parse('8:30am'), result.end
+    assert_equal time_parser.parse('8am'), result.begin
+    assert_equal time_parser.parse('8:30am'), result.end
   end
 
   def test_should_return_times_in_current_time_zone_if_set
@@ -165,8 +167,14 @@ class TimeRangeExtractorTest < Minitest::Test
       result = TimeRangeExtractor.call("8#{separator}9pm")
 
       assert_kind_of Range, result
-      assert_equal Time.parse('8pm'), result.begin
-      assert_equal Time.parse('9pm'), result.end
+      assert_equal time_parser.parse('8pm'), result.begin
+      assert_equal time_parser.parse('9pm'), result.end
     end
+  end
+
+  private
+
+  def time_parser
+    DateTime
   end
 end


### PR DESCRIPTION
A ruby bug in 2.6.x and earlier doesn't support mapping `AEST`, `AWST`.  This is fixed in newer versions of ruby however we are unable to upgrade to a new version at this point and this will fix it for older versions.

I didn't add ruby version detection to determine which MatchResult to load.  This could be extended in the future or the class could be removed entirely.

The default parser was switched from `Time` to `DateTime` as `Time` doesn't support parsing a `WAST` timezone unless the gem `tzinfo` was added.  I figured it's less harmful to switch to `DateTime` vs. adding a new dependency of `tzinfo`.