### PR TITLE
Require colon for minutes section of the time representation

### DIFF
--- a/lib/time_range_extractor/parser.rb
+++ b/lib/time_range_extractor/parser.rb
@@ -7,11 +7,11 @@ module TimeRangeExtractor
     PATTERN = /
       (\A|\s|\() # space or round bracket, to support: "Call Jim (8-9pm)"
       (
-        (?<start_time>(2[0-4]|1[0-9]|[1-9]):?([0-5][0-9])?)\s?
+        (?<start_time>(2[0-4]|1[0-9]|[1-9])(:[0-5][0-9])?)\s?
         (?<start_period>am|pm)?\s?
         (to|-|until|\s)\s?
       )
-      (?<end_time>(2[0-4]|1[0-9]|[1-9]):?([0-5][0-9])?)?\s?
+      (?<end_time>(2[0-4]|1[0-9]|[1-9])(:[0-5][0-9])?)?\s?
       (?<end_period>am|pm)\s?
       (?<time_zone>(
         [ABCDEFGHIJKLMNOPRSTUVWY]

--- a/test/time_range_extractor_test.rb
+++ b/test/time_range_extractor_test.rb
@@ -15,7 +15,10 @@ class TimeRangeExtractorTest < Minitest::Test
     '5:20pm',
     '5:20pm EST',
     '5:01 pm',
-    '5:00 AM CDT'
+    '5:00 AM CDT',
+    'Thu, 30 Jul 2020 5:00',
+    'Thu, 30 Jul 2020 5:00pm',
+    'Thu, 30 Jul 2020 5:00pm UTC',
   ].each do |time_string|
     define_method "test_should_not_handle_#{time_string.gsub(' ', '_')}" do
       assert_nil TimeRangeExtractor.call("Call at #{time_string} please")


### PR DESCRIPTION
Otherwise, a year could be parsed as time and an unxpected time range is found.